### PR TITLE
AppConfigService 추가

### DIFF
--- a/src/core/configs/app-config.service.ts
+++ b/src/core/configs/app-config.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+
+@Injectable()
+export class AppConfigService {
+  private readonly LOCAL = "local";
+  private readonly PRODUCTION = "production";
+
+  constructor(private configService: ConfigService) {}
+
+  get nodeEnv(): string {
+    return this.configService.get<string>("NODE_ENV") || this.LOCAL;
+  }
+
+  get isLocal(): boolean {
+    return this.nodeEnv === this.LOCAL;
+  }
+
+  get isProduction(): boolean {
+    return this.nodeEnv === this.PRODUCTION;
+  }
+}

--- a/src/core/configs/app-config.service.ts
+++ b/src/core/configs/app-config.service.ts
@@ -1,22 +1,22 @@
 import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
+const LOCAL = "local";
+const PRODUCTION = "production";
+
 @Injectable()
 export class AppConfigService {
-  private readonly LOCAL = "local";
-  private readonly PRODUCTION = "production";
-
   constructor(private configService: ConfigService) {}
 
   get nodeEnv(): string {
-    return this.configService.get<string>("NODE_ENV") || this.LOCAL;
+    return this.configService.get<string>("NODE_ENV") || LOCAL;
   }
 
   get isLocal(): boolean {
-    return this.nodeEnv === this.LOCAL;
+    return this.nodeEnv === LOCAL;
   }
 
   get isProduction(): boolean {
-    return this.nodeEnv === this.PRODUCTION;
+    return this.nodeEnv === PRODUCTION;
   }
 }

--- a/src/core/configs/app-config.service.ts
+++ b/src/core/configs/app-config.service.ts
@@ -19,4 +19,8 @@ export class AppConfigService {
   get isProduction(): boolean {
     return this.nodeEnv === PRODUCTION;
   }
+
+  get port(): number {
+    return this.configService.get<number>("PORT") || 3000;
+  }
 }

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -1,18 +1,24 @@
 import { Global, Logger, Module } from "@nestjs/common";
 import { APP_FILTER, APP_INTERCEPTOR } from "@nestjs/core";
+import { AppConfigService } from "@src/core/configs/app-config.service";
 import { HttpExceptionFilter } from "@src/core/filter/http-exception.filter";
 import { ResponseInterceptor } from "@src/core/interceptors/response.interceptor";
-import { winstonLogger } from "@src/core/logger/winston.config";
+import { createWinstonLogger } from "@src/core/logger/winston.config";
 import { WinstonLogger } from "@src/core/logger/winston.logger";
 import { BootstrapService } from "@src/core/services/bootstrap.service";
 
 @Global()
 @Module({
   providers: [
+    AppConfigService,
     BootstrapService,
     {
       provide: Logger,
-      useFactory: () => new WinstonLogger(winstonLogger),
+      inject: [AppConfigService],
+      useFactory: (appConfig: AppConfigService) => {
+        const loggerInstance = createWinstonLogger(appConfig);
+        return new WinstonLogger(loggerInstance);
+      },
     },
     {
       provide: APP_FILTER,
@@ -23,6 +29,6 @@ import { BootstrapService } from "@src/core/services/bootstrap.service";
       useClass: ResponseInterceptor,
     },
   ],
-  exports: [Logger, BootstrapService],
+  exports: [AppConfigService, Logger, BootstrapService],
 })
 export class CoreModule {}

--- a/src/core/filter/http-exception.filter.ts
+++ b/src/core/filter/http-exception.filter.ts
@@ -8,11 +8,15 @@ import {
   Logger,
   LoggerService,
 } from "@nestjs/common";
+import { AppConfigService } from "@src/core/configs/app-config.service";
 import { Request, Response } from "express";
 
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
-  constructor(@Inject(Logger) private readonly logger: LoggerService) {}
+  constructor(
+    @Inject(Logger) private readonly logger: LoggerService,
+    private readonly appConfigService: AppConfigService,
+  ) {}
 
   catch(exception: HttpException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
@@ -46,7 +50,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     }
 
     // 프로덕션 환경에서 500 에러 상세 정보 숨김 처리
-    const isProduction = process.env.NODE_ENV === "production";
+    const isProduction = this.appConfigService.isProduction;
     const responseError =
       isProduction && status >= HttpStatus.INTERNAL_SERVER_ERROR
         ? { message: "Internal Server Error" }

--- a/src/core/logger/winston.config.ts
+++ b/src/core/logger/winston.config.ts
@@ -1,3 +1,4 @@
+import { AppConfigService } from "@src/core/configs/app-config.service";
 import * as winston from "winston";
 
 const { combine, timestamp, printf, colorize } = winston.format;
@@ -22,17 +23,19 @@ const logFormat = printf(({ level, message, timestamp: time, context }) => {
  * - format: 타임스탬프와 커스텀 로그 포맷을 조합하여 사용합니다.
  * - transports: 로그를 출력할 대상을 설정합니다. (현재는 콘솔 출력만 설정됨)
  */
-export const winstonLogger = winston.createLogger({
-  // 프로덕션 환경에서는 info 레벨 이상, 개발 환경에서는 debug 레벨 이상을 로깅합니다.
-  level: process.env.NODE_ENV === "production" ? "info" : "debug",
+export const createWinstonLogger = (appConfig: AppConfigService) => {
+  return winston.createLogger({
+    // 프로덕션 환경에서는 info 레벨 이상, 개발 환경에서는 debug 레벨 이상을 로깅합니다.
+    level: appConfig.isProduction ? "info" : "debug",
 
-  transports: [
-    new winston.transports.Console({
-      format: combine(
-        timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
-        colorize({ all: true }),
-        logFormat,
-      ),
-    }),
-  ],
-});
+    transports: [
+      new winston.transports.Console({
+        format: combine(
+          timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
+          colorize({ all: true }),
+          logFormat,
+        ),
+      }),
+    ],
+  });
+};

--- a/src/core/services/bootstrap.service.ts
+++ b/src/core/services/bootstrap.service.ts
@@ -1,10 +1,13 @@
 import { INestApplication, Injectable } from "@nestjs/common";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { AppConfigService } from "@src/core/configs/app-config.service";
 
 @Injectable()
 export class BootstrapService {
+  constructor(private readonly appConfigService: AppConfigService) {}
+
   setupSwagger(app: INestApplication) {
-    if (process.env.NODE_ENV === "production") {
+    if (this.appConfigService.isProduction) {
       return;
     }
 

--- a/src/core/services/bootstrap.service.ts
+++ b/src/core/services/bootstrap.service.ts
@@ -44,7 +44,7 @@ export class BootstrapService {
   }
 
   async startServer(app: INestApplication) {
-    const port = process.env.PORT || 3000;
+    const port = this.appConfigService.port;
 
     await app.listen(port);
   }


### PR DESCRIPTION
## 🔗 이슈 번호
- Epic: #1 
- Task: Close #12 

## 💡 PR 요약
- env 파일 내 변수를 가져오기 위한 AppConfigService 구현

## 🛠 작업 내용
**✨ Feature**
- [ ] AppConfigService 구현

**♻️ Refactor**
- [ ] HttpExceptionFilter에서 isProduction 메서드를 사용하도록 수정
- [ ] BootstrapService 내 setupSwagger에서  isProduction 메서드를 사용하도록 수정
- [ ] winston logger 설정파일을 Factory 함수로 내보내도록 수정
- [ ] CoreModule에서 Logger를 제공할 때 AppConfigService를 주입받아 팩토리 함수에 전달하도록 수정

## 💬 리뷰 포인트
- AppConfigService 구현이 올바른지 확인해주세요.
- AppConfigService 내 메서드를 올바르게 사용하고 있는지 확인해주세요.

## 🔍 참고 자료
